### PR TITLE
fix(rolls): fix formatting of multi-dice type rolls going into TS

### DIFF
--- a/extension/js/main.js
+++ b/extension/js/main.js
@@ -107,7 +107,6 @@ document.addEventListener('keydown', function(e) {
  */
 function determineRollType(element) {
     let rollName = getRollNameFromString(element.getAttribute("name"));
-    console.warn(rollName);
     if (rollName == "initiative") {
         return ROLL_TYPES.Initiative;
     } else if (rollName == "hit_dice") {
@@ -267,5 +266,6 @@ function getAttackRollInformation(element) {
 function getDamageRollInformation(element) {
     let roll = element.getElementsByTagName("input")[0].value;
     modifier = parseDamageRollModifier(roll);
+    roll = roll.replace(/\s/g, ''); // TaleSpire does not like whitespaces in dice roll strings
     return new RollInformation(ROLL_TYPES.Damage, ROLL_TYPES.Damage, roll, modifier);
 }

--- a/extension/js/popup.js
+++ b/extension/js/popup.js
@@ -1,6 +1,7 @@
 // Fetch the input data from the popup and send it to TaleSpire
 document.getElementById("submitButton").addEventListener("click", async function() {
     let roll = document.getElementById("rollInput").value
+    roll = roll.replace(/\s/g, ''); // TaleSpire does not like whitespaces in dice roll strings
     let rollName = document.getElementById("rollNameInput").value || `${roll}`;
 
     // Takes a look at the advantage toggles and determines what the roll query is

--- a/extension/manifest.json
+++ b/extension/manifest.json
@@ -1,6 +1,6 @@
 {
   "name": "Roll20 to TaleSpire",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "description": "A TaleSpire companion application, used to send dice rolls from your Roll20 character sheet directly into your TaleSpire dice tray.",
   "manifest_version": 3,
   "author": "aptmac",


### PR DESCRIPTION
This PR fixes rolls that use more than 1 type of dice (e.g., `d6+2+1d4+3`)

The problem here was that using the Roll20 UI the roll information gets whitespace around the second dice type, which is unparseable by TaleSpire. The fix here is to just remove all white space from attack rolls from the roll20 side (it's the only place I think this can occur), and from all rolls on the popup side.

Also bumped the version to 0.0.2 so I can update the chrome store extension.